### PR TITLE
Sparc Protcur GoogleSheet update

### DIFF
--- a/sparcur/cli.py
+++ b/sparcur/cli.py
@@ -1705,9 +1705,8 @@ class Shell(Dispatcher):
         gc = gspread.oauth()  # add OAuth2 as ~/.config/gspread/credentials.json; will prop if missing something
         sparc_proctur = gc.open('sparc protcur annotation tags')
         worksheet = sparc_proctur.worksheet('working-ilxtr:technique')
-        df = pd.DataFrame(worksheet.get_all_values())
-        df.columns = df.iloc[0]  # first row is actually the header
-        df.drop(df.index[0], inplace=True)  # drop first row that was the header
+        row_list = worksheet.get_all_values()
+        df = pd.DataFrame(row_list[1:], columns=row_list[0])
 
         iris = []
         for row in df.itertuples():

--- a/sparcur/cli.py
+++ b/sparcur/cli.py
@@ -1705,8 +1705,8 @@ class Shell(Dispatcher):
         gc = gspread.oauth()  # add OAuth2 as ~/.config/gspread/credentials.json; will prop if missing something
         sparc_proctur = gc.open('sparc protcur annotation tags')
         worksheet = sparc_proctur.worksheet('working-ilxtr:technique')
-        row_list = worksheet.get_all_values()
-        df = pd.DataFrame(row_list[1:], columns=row_list[0])
+        header, *body = worksheet.get_all_values()
+        df = pd.DataFrame(body, columns=header)
 
         iris = []
         for row in df.itertuples():

--- a/sparcur/cli.py
+++ b/sparcur/cli.py
@@ -1693,8 +1693,8 @@ class Shell(Dispatcher):
     def ontologyIDPopulation(self):
         """ Update ontology id col based on exact column label
 
-             # https://gspread.readthedocs.io/en/latest/oauth2.html#oauth-client-id
-             # with google drive api enabled you can access each google sheet by name!
+            # https://gspread.readthedocs.io/en/latest/oauth2.html#oauth-client-id
+            # with google drive api enabled you can access each google sheet by name!
         """
         import gspread
         import pandas as pd
@@ -1702,7 +1702,7 @@ class Shell(Dispatcher):
 
         sgv = Vocabulary(cache=True, verbose=False)  # direct import seemed simple
 
-        gc = gspread.oauth()  # uses ~/.config/gspread/credentials.json; will prop if missing something
+        gc = gspread.oauth()  # add OAuth2 as ~/.config/gspread/credentials.json; will prop if missing something
         sparc_proctur = gc.open('sparc protcur annotation tags')
         worksheet = sparc_proctur.worksheet('working-ilxtr:technique')
         df = pd.DataFrame(worksheet.get_all_values())

--- a/sparcur/cli.py
+++ b/sparcur/cli.py
@@ -1691,13 +1691,18 @@ class Shell(Dispatcher):
         breakpoint()
 
     def ontologyIDPopulation(self):
-        import gspread  # https://gspread.readthedocs.io/en/latest/oauth2.html#oauth-client-id
-                        # with google drive api enabled you can access each google sheet by name!
+        """ Update ontology id col based on exact column label
+
+             # https://gspread.readthedocs.io/en/latest/oauth2.html#oauth-client-id
+             # with google drive api enabled you can access each google sheet by name!
+        """
+        import gspread
         import pandas as pd
         from pyontutils.scigraph import Graph, Vocabulary
-        sgv = Vocabulary(cache=True, verbose=False)
 
-        gc = gspread.oauth()
+        sgv = Vocabulary(cache=True, verbose=False)  # direct import seemed simple
+
+        gc = gspread.oauth()  # uses ~/.config/gspread/credentials.json; will prop if missing something
         sparc_proctur = gc.open('sparc protcur annotation tags')
         worksheet = sparc_proctur.worksheet('working-ilxtr:technique')
         df = pd.DataFrame(worksheet.get_all_values())
@@ -1715,6 +1720,7 @@ class Shell(Dispatcher):
             else:
                 iris.append(', '.join(_iris))
         df['ontology id'] = iris
+
         worksheet.update([df.columns.values.tolist()] + df.values.tolist())
 
 


### PR DESCRIPTION
API's have been updated to handle access to GoogleSheet directly with name and all sheets within it in one go. Here is an example of gspread using it. We could use gspread as the boilerplate and inject the .get_all_values() into your .values() to simplify upstream code. It would seem that https://github.com/burnash/gspread has now official support and won the battle of oauth2. 

I used sgv directly to avoid inheritance differences since I'm not accustom to the code.